### PR TITLE
Update jFeatureLib + Add SurfDemo + Fix examples

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>de.lmu.ifi.dbs.jfeaturelib</groupId>
             <artifactId>JFeatureLib</artifactId>
-            <version>1.6.2</version>
+            <version>1.6.3</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/src/main/java/de/lmu/dbs/ifi/jfeaturelib/examples/HaralickDemo.java
+++ b/src/main/java/de/lmu/dbs/ifi/jfeaturelib/examples/HaralickDemo.java
@@ -3,7 +3,7 @@ package de.lmu.dbs.ifi.jfeaturelib.examples;
 import de.lmu.ifi.dbs.jfeaturelib.features.Haralick;
 import de.lmu.ifi.dbs.utilities.Arrays2;
 import ij.process.ColorProcessor;
-import java.io.File;
+import java.io.InputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -19,8 +19,8 @@ public class HaralickDemo {
 
     public static void main(String[] args) throws IOException, URISyntaxException {
         // load the image
-        File f = new File(HaralickDemo.class.getResource("/test.jpg").toURI());
-        ColorProcessor image = new ColorProcessor(ImageIO.read(f));
+        InputStream stream = HaralickDemo.class.getClassLoader().getResourceAsStream("test.jpg");
+        ColorProcessor image = new ColorProcessor(ImageIO.read(stream));
 
         // initialize the descriptor
         Haralick descriptor = new Haralick();

--- a/src/main/java/de/lmu/dbs/ifi/jfeaturelib/examples/HistogramConfigDemo.java
+++ b/src/main/java/de/lmu/dbs/ifi/jfeaturelib/examples/HistogramConfigDemo.java
@@ -4,7 +4,7 @@ import de.lmu.ifi.dbs.jfeaturelib.LibProperties;
 import de.lmu.ifi.dbs.jfeaturelib.features.Histogram;
 import de.lmu.ifi.dbs.utilities.Arrays2;
 import ij.process.ColorProcessor;
-import java.io.File;
+import java.io.InputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -20,8 +20,8 @@ public class HistogramConfigDemo {
 
     public static void main(String[] args) throws IOException, URISyntaxException {
         // load the image
-        File f = new File(HistogramConfigDemo.class.getResource("/test.jpg").toURI());
-        ColorProcessor image = new ColorProcessor(ImageIO.read(f));
+        InputStream stream = HistogramConfigDemo.class.getClassLoader().getResourceAsStream("test.jpg");
+        ColorProcessor image = new ColorProcessor(ImageIO.read(stream));
 
         // load the properties from the default properties file
         // change the histogram to span just 2 bins

--- a/src/main/java/de/lmu/dbs/ifi/jfeaturelib/examples/StatusListenerDemo.java
+++ b/src/main/java/de/lmu/dbs/ifi/jfeaturelib/examples/StatusListenerDemo.java
@@ -5,7 +5,7 @@ import de.lmu.ifi.dbs.jfeaturelib.features.Haralick;
 import ij.process.ColorProcessor;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.io.File;
+import java.io.InputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import javax.imageio.ImageIO;
@@ -19,8 +19,8 @@ public class StatusListenerDemo {
 
     public static void main(String[] args) throws IOException, URISyntaxException {
         // load the image
-        File f = new File(StatusListenerDemo.class.getResource("/test.jpg").toURI());
-        ColorProcessor image = new ColorProcessor(ImageIO.read(f));
+        InputStream stream = StatusListenerDemo.class.getClassLoader().getResourceAsStream("test.jpg");
+        ColorProcessor image = new ColorProcessor(ImageIO.read(stream));
 
         // initialize the descriptor, attach the listener and run
         Haralick descriptor = new Haralick();

--- a/src/main/java/de/lmu/dbs/ifi/jfeaturelib/examples/SurfDemo.java
+++ b/src/main/java/de/lmu/dbs/ifi/jfeaturelib/examples/SurfDemo.java
@@ -1,0 +1,34 @@
+package de.lmu.dbs.ifi.jfeaturelib.examples;
+
+import de.lmu.ifi.dbs.jfeaturelib.features.SURF;
+import de.lmu.ifi.dbs.utilities.Arrays2;
+import ij.process.ColorProcessor;
+import java.io.InputStream;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.List;
+import javax.imageio.ImageIO;
+
+
+public class SurfDemo {
+
+    public static void main(String[] args) throws IOException, URISyntaxException {
+        // load the image
+        InputStream stream = SurfDemo.class.getClassLoader().getResourceAsStream("test.jpg");
+        ColorProcessor image = new ColorProcessor(ImageIO.read(stream));
+
+        // initialize the descriptor
+        SURF descriptor = new SURF();
+
+        // run the descriptor and extract the features
+        descriptor.run(image);
+
+        // obtain the features
+        List<double[]> features = descriptor.getFeatures();
+
+        // print the features to system out
+        for (double[] feature : features) {
+            System.out.println(Arrays2.join(feature, ", ", "%.5f"));
+        }
+    }
+}


### PR DESCRIPTION
Tested with:
mvn exec:java -Dexec.mainClass="de.lmu.dbs.ifi.jfeaturelib.examples.HaralickDemo"
[INFO] Scanning for projects...
[INFO]  
[INFO] ------------------------------------------------------------------------
[INFO] Building JFeatureLib-Demos 1.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[WARNING] The POM for com.github.kzwang:lire:jar:0.9.4-kzwang-beta1 is invalid, transitive dependencies (if any) will not be available, enable debug logging for more details
[INFO] 
[INFO] --- exec-maven-plugin:1.3.2:java (default-cli) @ Demos ---
[WARNING] Warning: killAfter is now deprecated. Do you need it ? Please comment on MEXEC-6.
0.01477, 6.82030, 248111.58382, 9620.12020, 0.48620, 27.65756, 183.01273, 3.62245, 5.08241, 3.84908, 1.76743, -0.31227, 0.91518, 1.13266
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.748 s
[INFO] Finished at: 2016-01-14T14:41:52+08:00
[INFO] Final Memory: 13M/477M
[INFO] ------------------------------------------------------------------------

samos@sams-thinkpad ‹ master ↑●● › : ~/workspace/JFeatureLib-Demo
[0] % mvn exec:java -Dexec.mainClass="de.lmu.dbs.ifi.jfeaturelib.examples.HistogramConfigDemo"
[INFO] Scanning for projects...
[INFO]  
[INFO] ------------------------------------------------------------------------
[INFO] Building JFeatureLib-Demos 1.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[WARNING] The POM for com.github.kzwang:lire:jar:0.9.4-kzwang-beta1 is invalid, transitive dependencies (if any) will not be available, enable debug logging for more details
[INFO] 
[INFO] --- exec-maven-plugin:1.3.2:java (default-cli) @ Demos ---
[WARNING] Warning: killAfter is now deprecated. Do you need it ? Please comment on MEXEC-6.
49775.00000, 32179.00000
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.675 s
[INFO] Finished at: 2016-01-14T14:42:27+08:00
[INFO] Final Memory: 14M/482M
[INFO] ------------------------------------------------------------------------

mvn exec:java -Dexec.mainClass="de.lmu.dbs.ifi.jfeaturelib.examples.StatusListenerDemo" 
[INFO] Scanning for projects...
[INFO]  
[INFO] ------------------------------------------------------------------------
[INFO] Building JFeatureLib-Demos 1.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[WARNING] The POM for com.github.kzwang:lire:jar:0.9.4-kzwang-beta1 is invalid, transitive dependencies (if any) will not be available, enable debug logging for more details
[INFO] 
[INFO] --- exec-maven-plugin:1.3.2:java (default-cli) @ Demos ---
[WARNING] Warning: killAfter is now deprecated. Do you need it ? Please comment on MEXEC-6.
0%: started
1%: creating coocurrence matrix
25%: normalizing
50%: computing statistics
75%: computing features
100%: finished
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.715 s
[INFO] Finished at: 2016-01-14T14:42:50+08:00
[INFO] Final Memory: 13M/482M
[INFO] ------------------------------------------------------------------------
